### PR TITLE
Improved Testing Code for K30

### DIFF
--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -13,7 +13,8 @@
 #define XBEE_BAUD_RATE 115200  
 
 // K30 configuration
-#define K30_I2C_ADDR 0x68     // K30 default 7-bit address
+// Changed from 0x68 to 0x69 to avoid conflict with the data logger
+#define K30_I2C_ADDR 0x69     // K30 default 7-bit address: 0x68; Any Sensor address: 0x7F
 #define MAX_RETRIES 3         // Retries before resetting I2C bus
 
 // I2C hardware pins (Uno/Nano): A4 = SDA, A5 = SCL

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -11,6 +11,7 @@
 // TODO
 // - Check "Error Status" at 0x1E (See section 8 of data sheet) periodically
 //   to detect sensor faults (e.g. dirty optics) and report them via XBee.
+// - Non-blocking startup timer to allow K30 warm-up without triggering watchdog timer
 //
 
 #include <Wire.h>
@@ -53,6 +54,9 @@ void setup() {
   Wire.begin();
   Wire.setClock(I2C_CLOCK_SPEED); 
   
+  // Warning: This will trigger the watchdog timer in the production system
+  // but is necessary to prevent the K30 from locking up when the system first powers on.
+  // TODO: figure out how to create a non-blocking startup timer that allows the K30 to warm up without triggering the watchdog.
   XBee.print(F("K30 I2C CO2 sensor - warming up..."));  
   delay(WARMUP_MS);
 
@@ -60,6 +64,10 @@ void setup() {
   // to detect sensor faults before continuing
 
   XBee.println(F("Ready."));
+
+  // Put the I2C bus into a known state
+  XBee.print(F("Initializing I2C bus..."));
+  recoverI2CBus();
   
 }
 
@@ -71,6 +79,7 @@ void loop() {
     
   } else {
     XBee.println(F("CO2 read failed after retries"));
+    XBee.println(F("Recovering I2C bus..."));
     recoverI2CBus();
   }
   // K30 can lock up if read too frequently, so delay before next read
@@ -207,7 +216,6 @@ int readK30_CO2_withRetry() {
 //   Reference: NXP UM10204 I2C-bus specification §3.1.16
 // ══════════════════════════════════════════════════════════════════════════════
 void recoverI2CBus() {
-  XBee.println(F("Recovering I2C bus..."));
 
   // Release the Wire library before bit-banging the pins directly.
   Wire.end();
@@ -246,5 +254,5 @@ void recoverI2CBus() {
   Wire.begin();
   Wire.setClock(I2C_CLOCK_SPEED);
 
-  XBee.println(F("I2C bus recovery complete."));
+  XBee.println(F("I2C bus initialized"));
 }

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -1,170 +1,197 @@
-// CO2 Meter K-series Example Interface
-// Revised by Marv Kausch, 7/2016 at CO2 Meter <co2meter.com>
-// Talks via I2C to K30/K22/K33/Logger sensors and displays CO2 values
-// 12/31/09
+// Arduino sketch for reading Sensair K30 CO2 sensor over I2C and sending data via XBee.
+// Includes a retry mechanism and bus recovery to handle common I2C issues with the K30
+// when used with long wires or in electrically noisy environments.
+// Author: Jon Jaroker
+// License: MIT
+
 #include <Wire.h>
-// We will be using the I2C hardware interface on the Arduino in
-// combination with the built-in Wire library to interface.
-// Arduino analog input 5 - I2C SCL
-// Arduino analog input 4 - I2C SDA
-/*
-  In this example we will do a basic read of the CO2 value and checksum verification.
-  For more advanced applications please see the I2C Comm guide.
-*/
-int co2Addr = 0x68;
-// This is the default address of the CO2 sensor, 7bits shifted left.
+#include <SoftwareSerial.h>
 
-// if using a CO2Meter CM-200 Sensor Development Board, set this to 1 if you want the LEDs to flash
-// if you're wiring directly to the sensor, set this to 0
-#define CM200 1
+// XBee configuration
+// Use 115200 to minimize interference with actuator servo
+// Default is 9600 but that can cause more noise issues on the I2C
+#define XBEE_BAUD_RATE 115200  
 
-#if CM200
-#define GREEN_LED 4
-#define BLUE_LED 5
-#define RED_LED 6
+// K30 configuration
+#define K30_I2C_ADDR 0x68     // K30 default 7-bit address
+#define MAX_RETRIES 3         // Retries before resetting I2C bus
 
-uint8_t ind = GREEN_LED;
-#endif
+// I2C hardware pins (Uno/Nano): A4 = SDA, A5 = SCL
+// These two pins are also used for the software I2C bus-recovery routine.
+#define I2C_SCL_PIN  A5
+#define I2C_SDA_PIN  A4
+
+// Lower I2C clock to 50 kHz — more reliable on long wires than the 100 kHz
+// default; lower chance of noise-induced glitches locking up the bus.
+#define I2C_CLOCK_SPEED 50000UL 
+#define I2C_TIMEOUT_MS 50UL   // Timeout for I2C reads (prevents infinite loop if sensor stops clocking)
+
+// Datasheet Timing Constants
+#define CMD_DELAY_MS 20       // K30 datasheet: ≥20 ms after write
+#define RETRY_BACKOFF_MS 50   // extra wait between retries
+#define WARMUP_MS 10000UL     // K30 power-on warm-up
+
+
+// Set up XBee on digital pins 2 and 3
+SoftwareSerial XBee(2, 3); // Arduino RX, TX (XBee Dout, Din)
 
 void setup() {
-  Serial.begin(9600);
-  Wire.begin ();
-  pinMode(13, OUTPUT); // address of the Arduino LED indicator
-  Serial.println("Application Note AN-102: Interface Arduino to K-30");
-
-#if CM200
-  pinMode(GREEN_LED, OUTPUT);
-  pinMode(BLUE_LED, OUTPUT);
-  pinMode(RED_LED, OUTPUT);
-
-  digitalWrite(GREEN_LED, LOW);
-  digitalWrite(BLUE_LED, LOW);
-  digitalWrite(RED_LED, LOW);
-#endif
+  
+  // Initialize XBee Software Serial port. 
+  XBee.begin(XBEE_BAUD_RATE); 
+  
+  Wire.begin();
+  Wire.setClock(I2C_CLOCK_SPEED); 
+  
+  XBee.print("K30 I2C CO2 sensor – warming up...");  
+  delay(WARMUP_MS);
+  XBee.println("Ready.");
+  
 }
-///////////////////////////////////////////////////////////////////
-// Function : int readCO2()
-// Returns : CO2 Value upon success, 0 upon checksum failure
-// Assumes : - Wire library has been imported successfully.
-// - LED is connected to IO pin 13
-// - CO2 sensor address is defined in co2_addr
-///////////////////////////////////////////////////////////////////
-int readCO2() {
-  int co2_value = 0;  // We will store the CO2 value inside this variable.
 
-  digitalWrite(13, HIGH);  // turn on LED
-  // On most Arduino platforms this pin is used as an indicator light.
-
-  //////////////////////////
-  /* Begin Write Sequence */
-  //////////////////////////
-
-  Wire.beginTransmission(co2Addr);
-  Wire.write(0x22);
-  Wire.write(0x00);
-  Wire.write(0x08);
-  Wire.write(0x2A);
-
-  Wire.endTransmission();
-
-  /////////////////////////
-  /* End Write Sequence. */
-  /////////////////////////
-
-  /*
-    We wait 10ms for the sensor to process our command.
-    The sensors's primary duties are to accurately
-    measure CO2 values. Waiting 10ms will ensure the
-    data is properly written to RAM
-
-  */
-
-  delay(10);
-
-  /////////////////////////
-  /* Begin Read Sequence */
-  /////////////////////////
-
-  /*
-    Since we requested 2 bytes from the sensor we must
-    read in 4 bytes. This includes the payload, checksum,
-    and command status byte.
-
-  */
-
-  Wire.requestFrom(co2Addr, 4);
-
-  byte i = 0;
-  byte buffer[4] = {0, 0, 0, 0};
-
-  /*
-    Wire.available() is not nessessary. Implementation is obscure but we leave
-    it in here for portability and to future proof our code
-  */
-  while (Wire.available())
-  {
-    buffer[i] = Wire.read();
-    i++;
-  }
-
-  ///////////////////////
-  /* End Read Sequence */
-  ///////////////////////
-
-  /*
-    Using some bitwise manipulation we will shift our buffer
-    into an integer for general consumption
-  */
-
-  co2_value = 0;
-  co2_value |= buffer[1] & 0xFF;
-  co2_value = co2_value << 8;
-  co2_value |= buffer[2] & 0xFF;
-
-
-  byte sum = 0; //Checksum Byte
-  sum = buffer[0] + buffer[1] + buffer[2]; //Byte addition utilizes overflow
-
-  if (sum == buffer[3])
-  {
-    // Success!
-    digitalWrite(13, LOW);
-    return co2_value;
-  }
-  else
-  {
-    // Failure!
-    /*
-      Checksum failure can be due to a number of factors,
-      fuzzy electrons, sensor busy, etc.
-    */
-
-    digitalWrite(13, LOW);
-    return 0;
-  }
-}
 void loop() {
-#if CM200
-  // if using a CM-200 we can cycle through the LEDs to high and low so we can see that we're in the loop
-  if (digitalRead(ind) == HIGH)
-    digitalWrite(ind, LOW);
-  else
-    digitalWrite(ind, HIGH);
-
-  ind++;
-  if (ind > RED_LED)
-    ind = GREEN_LED;
-#endif
-
-  int co2Value = readCO2();
-  if (co2Value > 0)
-  {
-    Serial.print("CO2 Value: ");
-    Serial.println(co2Value);
+  int co2 = readK30_CO2_withRetry();
+  if (co2 > 0) {
+    XBee.print("CO2 ppm: ");
+    XBee.println(co2);
+    
+  } else {
+    XBee.println("CO2 read failed after retries");
+    recoverI2CBus();
   }
-  else
-  {
-    Serial.println("Checksum failed / Communication failure");
+  // K30 can lock up if read too frequently, so delay before next read
+  delay(2500);
+}
+
+// Returns ppm or -1 on failure
+int readK30_CO2_withRetry() {
+  for (int retry = 0; retry < MAX_RETRIES; retry++) {
+    Wire.beginTransmission(K30_I2C_ADDR);
+    // K30 command: function 0x22, read 2 bytes starting at address 0x0008.
+    Wire.write(0x22);
+    Wire.write(0x00);
+    Wire.write(0x08);
+    // Checksum = sum of all command bytes (0x22 + 0x00 + 0x08 = 0x2A).
+    Wire.write(0x2A);
+
+    uint8_t err = Wire.endTransmission();
+    if (err != 0) {
+      // err codes: 1=data too long, 2=NACK on address, 3=NACK on data, 4=other
+      XBee.print("endTransmission error: "); XBee.println(err);
+      delay(RETRY_BACKOFF_MS);
+      continue;
+    }
+
+    // The K30 datasheet specifies ≥20 ms for the sensor to finish writing
+    // the result to RAM before you read it back. The original 10 ms caused 
+    // intermittent checksum failures.
+    delay(CMD_DELAY_MS);  
+
+    // Read 4 bytes: status, MSB, LSB, checksum
+    uint8_t received = Wire.requestFrom(K30_I2C_ADDR, (uint8_t)4);  // cast '4' to uint8_t to avoid warning about signed/unsigned mismatch
+
+    // Confirm we got 4 bytes back; if not, something went wrong at the I2C level.
+    if (received != 4) { // alternative: Wire.available() != 4
+      XBee.println("ERROR: Expected 4 bytes, got " + String(received));
+      // Drain any leftover bytes to avoid poisoning the next transaction.
+      while (Wire.available()) Wire.read();
+      delay(RETRY_BACKOFF_MS);
+      continue;
+    }
+
+    // Timeout-guarded read — prevents infinite loop if sensor stops clocking.
+    uint8_t buf[4];
+    unsigned long startMs = millis();
+
+    int bytesRead = 0;
+    while (bytesRead < 4 && (millis() - startMs) < I2C_TIMEOUT_MS) {
+      if (Wire.available() > 0) {
+        buf[bytesRead++] = Wire.read();
+      } else {
+        delayMicroseconds(100);  // Prevent 100% CPU utilization
+      }
+    }
+
+    if (bytesRead != 4) {
+      while (Wire.available()) Wire.read();  // flush partial data
+      XBee.print("ERROR: Timeout Occurred. Received ");
+      XBee.print(bytesRead);
+      XBee.println(" bytes instead of 4");
+      delay(RETRY_BACKOFF_MS);
+      continue;  // retry
+    }
+
+    // Assemble the reading into a measurement and verify checksum
+    uint8_t checksum = buf[0] + buf[1] + buf[2];
+    if (checksum != buf[3]) {
+      XBee.println("ERROR: Checksum fail");
+      delay(RETRY_BACKOFF_MS);
+      continue;
+    }
+
+    //The expression (buf[1] << 8) promotes to int but shifts into or past the 
+    // sign bit for any value ≥ 128 — undefined behavior in C/C++. 
+    // For CO2 readings above ~32767 ppm (unlikely but possible in fault modes) 
+    // the result could be spuriously negative. Fixed by casting first
+    uint16_t co2 = ((uint16_t)buf[1] << 8) | buf[2];
+    if (co2 == 0 || co2 > 10000) continue;  // 0 ppm is invalid; >10000 is out of K30 range
+
+    return co2;
   }
-  delay(2000);
+  return -1;
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// recoverI2CBus()
+//   Recovers a locked-up I2C bus by bit-banging up to 9 SCL pulses while SDA
+//   is held high, then issuing a START followed by a STOP condition.
+//
+//   A lockup happens when the master resets (e.g. watchdog) mid-transaction:
+//   the slave still holds SDA low waiting for more SCL pulses.  Nine clocks
+//   are the worst-case number needed to clock out whatever byte the slave is
+//   stuck on, regardless of which bit it was on when the master reset.
+//
+//   Reference: NXP UM10204 I2C-bus specification §3.1.16
+// ══════════════════════════════════════════════════════════════════════════════
+void recoverI2CBus() {
+  XBee.println("Recovering I2C bus...");
+
+  // Release the Wire library before bit-banging the pins directly.
+  Wire.end();
+
+  // SCL driven by us; SDA must be INPUT_PULLUP so we can actually read the bus state
+  pinMode(I2C_SCL_PIN, OUTPUT);
+  pinMode(I2C_SDA_PIN, INPUT_PULLUP);
+  delayMicroseconds(5);
+
+  for (uint8_t i = 0; i < 9; i++) {
+    digitalWrite(I2C_SCL_PIN, HIGH);
+    delayMicroseconds(5);
+    // If SDA has gone high the slave has released the bus — we can stop early.
+    if (digitalRead(I2C_SDA_PIN) == HIGH) break;
+    digitalWrite(I2C_SCL_PIN, LOW);
+    delayMicroseconds(5);
+  }
+
+  // Issue a STOP condition
+  digitalWrite(I2C_SCL_PIN, LOW);   // ensure SCL is low before SDA manipulation
+  delayMicroseconds(5);
+  pinMode(I2C_SDA_PIN, OUTPUT);
+  digitalWrite(I2C_SDA_PIN, LOW);   // SDA low (with SCL low — safe)
+  delayMicroseconds(5);
+  digitalWrite(I2C_SCL_PIN, HIGH);  // SCL high
+  delayMicroseconds(5);
+  digitalWrite(I2C_SDA_PIN, HIGH);  // SDA high while SCL high = STOP
+
+  // Release both pins to INPUT_PULLUP before handing them back to Wire,
+  // so Wire.begin() can cleanly take ownership without fighting an OUTPUT driver.
+  pinMode(I2C_SCL_PIN, INPUT_PULLUP);
+  pinMode(I2C_SDA_PIN, INPUT_PULLUP);
+  delayMicroseconds(5);
+
+  // Re-initialise Wire and restore reduced clock speed.
+  Wire.begin();
+  Wire.setClock(I2C_CLOCK_SPEED);
+
+  XBee.println(F("I2C bus recovery complete."));
 }

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -136,7 +136,8 @@ int16_t readK30_CO2_withRetry() {
 
     // Confirm we got 4 bytes back; if not, something went wrong at the I2C level.
     if (received != 4) { // alternative: Wire.available() != 4
-      XBee.println(F("ERROR: Expected 4 bytes, got " + String(received)));
+      XBee.print(F("ERROR: Expected 4 bytes, got "));
+      XBee.println(received);
       // Drain any leftover bytes to avoid poisoning the next transaction.
       XBee.print(F("Flushing I2C buffer..."));
       while (Wire.available()) Wire.read();  // flush partial data

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -199,7 +199,8 @@ int16_t readK30_CO2_withRetry() {
 
     // Expect CO2 in a reasonable range for ambient air; if not, something went wrong
     if (co2 == 0 || co2 > 10000) { // 0 ppm is invalid; >10000 is out of K30 range
-      XBee.println(F("ERROR: Invalid CO2 reading: " + String(co2)));
+      XBee.println(F("ERROR: Invalid CO2 reading: ") );
+      XBee.println(co2);
       delay(RETRY_BACKOFF_MS);
       continue;
     }

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -4,6 +4,11 @@
 // Author: Jon Jaroker
 // License: MIT
 
+// TODO
+// - Read "Error Status" at 0x1E (See section 8 of data sheet) periodically
+//   to detect sensor faults (e.g. dirty optics) and report them via XBee.
+//
+
 #include <Wire.h>
 #include <SoftwareSerial.h>
 
@@ -22,8 +27,8 @@
 #define I2C_SCL_PIN  A5
 #define I2C_SDA_PIN  A4
 
-// Lower I2C clock to 50 kHz — more reliable on long wires than the 100 kHz
-// default; lower chance of noise-induced glitches locking up the bus.
+// Lower I2C clock to 50 kHz — more reliable on long wires than the 100 kHz default
+// K30 SCL clock frequency is 100kHz
 #define I2C_CLOCK_SPEED 50000UL 
 #define I2C_TIMEOUT_MS 50UL   // Timeout for I2C reads (prevents infinite loop if sensor stops clocking)
 
@@ -68,12 +73,19 @@ void loop() {
 int readK30_CO2_withRetry() {
   for (int retry = 0; retry < MAX_RETRIES; retry++) {
     Wire.beginTransmission(K30_I2C_ADDR);
-    // K30 command: function 0x22, read 2 bytes starting at address 0x0008.
-    Wire.write(0x22);
-    Wire.write(0x00);
-    Wire.write(0x08);
+
+    //
+    // K30 Request Command
+    //
+    // Read Ram
+    //  Byte 1 - Command 0x22 (ReadRam with 2 data bytes)
+    //  Byte 2-3 - address 0x0008 ("Space CO2")
+    //  Byte 4 - checksum
+    Wire.write(0x22); // 7:4 Command bits: 0x2 = read; 3:0 Num of Data bytes to read: 0x2 = 2 bytes (MSB + LSB)
+    Wire.write(0x00); // Address MSB 
+    Wire.write(0x08); // Address LSB
     // Checksum = sum of all command bytes (0x22 + 0x00 + 0x08 = 0x2A).
-    Wire.write(0x2A);
+    Wire.write(0x2A);  // Checksum
 
     uint8_t err = Wire.endTransmission();
     if (err != 0) {
@@ -88,7 +100,13 @@ int readK30_CO2_withRetry() {
     // intermittent checksum failures.
     delay(CMD_DELAY_MS);  
 
-    // Read 4 bytes: status, MSB, LSB, checksum
+    //
+    // K30 Response
+    //
+    // Expect 4 Bytes (Section 5.3 Read Ram)
+    //  Byte 1 - Status (0x21 "Read Complete" or 0x22 "Read Incomplete")
+    //  Byte 2-3 - Data (MSB + LSB)
+    //  Byte 4 - Checksum
     uint8_t received = Wire.requestFrom(K30_I2C_ADDR, (uint8_t)4);  // cast '4' to uint8_t to avoid warning about signed/unsigned mismatch
 
     // Confirm we got 4 bytes back; if not, something went wrong at the I2C level.
@@ -103,8 +121,8 @@ int readK30_CO2_withRetry() {
     // Timeout-guarded read — prevents infinite loop if sensor stops clocking.
     uint8_t buf[4];
     unsigned long startMs = millis();
-
     int bytesRead = 0;
+
     while (bytesRead < 4 && (millis() - startMs) < I2C_TIMEOUT_MS) {
       if (Wire.available() > 0) {
         buf[bytesRead++] = Wire.read();
@@ -113,6 +131,7 @@ int readK30_CO2_withRetry() {
       }
     }
 
+    // Expect 4 bytes
     if (bytesRead != 4) {
       XBee.print("ERROR: Timeout Occurred. Loaded ");
       XBee.print(bytesRead);
@@ -122,7 +141,15 @@ int readK30_CO2_withRetry() {
       continue;  // retry
     }
 
-    // Assemble the reading into a measurement and verify checksum
+    // Expect status byte 0x21 "Read Complete"
+    if (buf[0] != 0x21) {
+      XBee.print("ERROR: Sensor status indicates read incomplete: 0x"); 
+      XBee.println(buf[0], HEX);
+      delay(RETRY_BACKOFF_MS);
+      continue;
+    }
+
+    // Verify checksum
     uint8_t checksum = buf[0] + buf[1] + buf[2];
     if (checksum != buf[3]) {
       XBee.println("ERROR: Checksum fail");
@@ -130,7 +157,8 @@ int readK30_CO2_withRetry() {
       continue;
     }
 
-    //The expression (buf[1] << 8) promotes to int but shifts into or past the 
+    // Assemble CO2 value from MSB and LSB
+    // The expression (buf[1] << 8) promotes to int but shifts into or past the 
     // sign bit for any value ≥ 128 — undefined behavior in C/C++. 
     // For CO2 readings above ~32767 ppm (unlikely but possible in fault modes) 
     // the result could be spuriously negative. Fixed by casting first

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -199,7 +199,7 @@ int16_t readK30_CO2_withRetry() {
 
     // Expect CO2 in a reasonable range for ambient air; if not, something went wrong
     if (co2 == 0 || co2 > 10000) { // 0 ppm is invalid; >10000 is out of K30 range
-      XBee.println(F("ERROR: Invalid CO2 reading: ") );
+      XBee.print(F("ERROR: Invalid CO2 reading: ") );
       XBee.println(co2);
       delay(RETRY_BACKOFF_MS);
       continue;

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -1,11 +1,15 @@
 // Arduino sketch for reading Sensair K30 CO2 sensor over I2C and sending data via XBee.
 // Includes a retry mechanism and bus recovery to handle common I2C issues with the K30
 // when used with long wires or in electrically noisy environments.
+//
+// Error handling and expected behavior is designed according to Sensair data sheet:
+// https://rmtplusstoragesenseair.blob.core.windows.net/docs/Dev/publicerat/TDE4700.pdf
+//
 // Author: Jon Jaroker
 // License: MIT
 
 // TODO
-// - Read "Error Status" at 0x1E (See section 8 of data sheet) periodically
+// - Check "Error Status" at 0x1E (See section 8 of data sheet) periodically
 //   to detect sensor faults (e.g. dirty optics) and report them via XBee.
 //
 
@@ -136,7 +140,9 @@ int readK30_CO2_withRetry() {
       XBee.print("ERROR: Timeout Occurred. Loaded ");
       XBee.print(bytesRead);
       XBee.println(" bytes instead of 4");
+      XBee.print("Flushing I2C buffer...");
       while (Wire.available()) Wire.read();  // flush partial data
+      XBee.println("done");
       delay(RETRY_BACKOFF_MS);
       continue;  // retry
     }
@@ -163,12 +169,15 @@ int readK30_CO2_withRetry() {
     // For CO2 readings above ~32767 ppm (unlikely but possible in fault modes) 
     // the result could be spuriously negative. Fixed by casting first
     uint16_t co2 = ((uint16_t)buf[1] << 8) | buf[2];
+
+    // Expect CO2 in a reasonable range for ambient air; if not, something went wrong
     if (co2 == 0 || co2 > 10000) { // 0 ppm is invalid; >10000 is out of K30 range
       XBee.println("ERROR: Invalid CO2 reading: " + String(co2));
       delay(RETRY_BACKOFF_MS);
       continue
     };  
 
+    // Successful read with valid checksum and plausible CO2 value
     return co2;
   }
   return -1;

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -55,6 +55,10 @@ void setup() {
   
   XBee.print("K30 I2C CO2 sensor – warming up...");  
   delay(WARMUP_MS);
+
+  // TODO - Check "Error Status" at 0x1E (See section 8 of data sheet) 
+  // to detect sensor faults before continuing
+  
   XBee.println("Ready.");
   
 }
@@ -117,7 +121,9 @@ int readK30_CO2_withRetry() {
     if (received != 4) { // alternative: Wire.available() != 4
       XBee.println("ERROR: Expected 4 bytes, got " + String(received));
       // Drain any leftover bytes to avoid poisoning the next transaction.
-      while (Wire.available()) Wire.read();
+      XBee.print("Flushing I2C buffer...");
+      while (Wire.available()) Wire.read();  // flush partial data
+      XBee.println("done");
       delay(RETRY_BACKOFF_MS);
       continue;
     }

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -113,10 +113,10 @@ int readK30_CO2_withRetry() {
     }
 
     if (bytesRead != 4) {
-      while (Wire.available()) Wire.read();  // flush partial data
-      XBee.print("ERROR: Timeout Occurred. Received ");
+      XBee.print("ERROR: Timeout Occurred. Loaded ");
       XBee.print(bytesRead);
       XBee.println(" bytes instead of 4");
+      while (Wire.available()) Wire.read();  // flush partial data
       delay(RETRY_BACKOFF_MS);
       continue;  // retry
     }
@@ -134,7 +134,11 @@ int readK30_CO2_withRetry() {
     // For CO2 readings above ~32767 ppm (unlikely but possible in fault modes) 
     // the result could be spuriously negative. Fixed by casting first
     uint16_t co2 = ((uint16_t)buf[1] << 8) | buf[2];
-    if (co2 == 0 || co2 > 10000) continue;  // 0 ppm is invalid; >10000 is out of K30 range
+    if (co2 == 0 || co2 > 10000) { // 0 ppm is invalid; >10000 is out of K30 range
+      XBee.println("ERROR: Invalid CO2 reading: " + String(co2));
+      delay(RETRY_BACKOFF_MS);
+      continue
+    };  
 
     return co2;
   }

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -53,24 +53,24 @@ void setup() {
   Wire.begin();
   Wire.setClock(I2C_CLOCK_SPEED); 
   
-  XBee.print("K30 I2C CO2 sensor – warming up...");  
+  XBee.print(F("K30 I2C CO2 sensor - warming up..."));  
   delay(WARMUP_MS);
 
   // TODO - Check "Error Status" at 0x1E (See section 8 of data sheet) 
   // to detect sensor faults before continuing
-  
-  XBee.println("Ready.");
+
+  XBee.println(F("Ready."));
   
 }
 
 void loop() {
   int co2 = readK30_CO2_withRetry();
   if (co2 > 0) {
-    XBee.print("CO2 ppm: ");
+    XBee.print(F("CO2 ppm: "));
     XBee.println(co2);
     
   } else {
-    XBee.println("CO2 read failed after retries");
+    XBee.println(F("CO2 read failed after retries"));
     recoverI2CBus();
   }
   // K30 can lock up if read too frequently, so delay before next read
@@ -98,7 +98,7 @@ int readK30_CO2_withRetry() {
     uint8_t err = Wire.endTransmission();
     if (err != 0) {
       // err codes: 1=data too long, 2=NACK on address, 3=NACK on data, 4=other
-      XBee.print("endTransmission error: "); XBee.println(err);
+      XBee.print(F("endTransmission error: ")); XBee.println(err);
       delay(RETRY_BACKOFF_MS);
       continue;
     }
@@ -115,20 +115,23 @@ int readK30_CO2_withRetry() {
     //  Byte 1 - Status (0x21 "Read Complete" or 0x22 "Read Incomplete")
     //  Byte 2-3 - Data (MSB + LSB)
     //  Byte 4 - Checksum
+
+    // Fill wire buffer with response from K30
     uint8_t received = Wire.requestFrom(K30_I2C_ADDR, (uint8_t)4);  // cast '4' to uint8_t to avoid warning about signed/unsigned mismatch
 
     // Confirm we got 4 bytes back; if not, something went wrong at the I2C level.
     if (received != 4) { // alternative: Wire.available() != 4
-      XBee.println("ERROR: Expected 4 bytes, got " + String(received));
+      XBee.println(F("ERROR: Expected 4 bytes, got " + String(received)));
       // Drain any leftover bytes to avoid poisoning the next transaction.
-      XBee.print("Flushing I2C buffer...");
+      XBee.print(F("Flushing I2C buffer..."));
       while (Wire.available()) Wire.read();  // flush partial data
-      XBee.println("done");
+      XBee.println(F("done"));
       delay(RETRY_BACKOFF_MS);
       continue;
     }
 
-    // Timeout-guarded read — prevents infinite loop if sensor stops clocking.
+    // Timeout-guarded read — prevents infinite loop if sensor stops clocking
+    // Load the wire buffer into an array for processing
     uint8_t buf[4];
     unsigned long startMs = millis();
     int bytesRead = 0;
@@ -141,21 +144,23 @@ int readK30_CO2_withRetry() {
       }
     }
 
-    // Expect 4 bytes
+    // Expect buffer to be loaded within timeout
+    // This is a redundant check given the earlier check on Wire.requestFrom(), 
+    // but is used here to guard against and troubleshoot I2C lockups
     if (bytesRead != 4) {
-      XBee.print("ERROR: Timeout Occurred. Loaded ");
+      XBee.print(F("ERROR: Timeout Occurred. Loaded "));
       XBee.print(bytesRead);
-      XBee.println(" bytes instead of 4");
-      XBee.print("Flushing I2C buffer...");
+      XBee.println(F(" bytes instead of 4"));
+      XBee.print(F("Flushing I2C buffer..."));
       while (Wire.available()) Wire.read();  // flush partial data
-      XBee.println("done");
+      XBee.println(F("done"));
       delay(RETRY_BACKOFF_MS);
       continue;  // retry
     }
 
     // Expect status byte 0x21 "Read Complete"
     if (buf[0] != 0x21) {
-      XBee.print("ERROR: Sensor status indicates read incomplete: 0x"); 
+      XBee.print(F("ERROR: Sensor status indicates read incomplete: 0x")); 
       XBee.println(buf[0], HEX);
       delay(RETRY_BACKOFF_MS);
       continue;
@@ -164,7 +169,7 @@ int readK30_CO2_withRetry() {
     // Verify checksum
     uint8_t checksum = buf[0] + buf[1] + buf[2];
     if (checksum != buf[3]) {
-      XBee.println("ERROR: Checksum fail");
+      XBee.println(F("ERROR: Checksum fail"));
       delay(RETRY_BACKOFF_MS);
       continue;
     }
@@ -178,10 +183,10 @@ int readK30_CO2_withRetry() {
 
     // Expect CO2 in a reasonable range for ambient air; if not, something went wrong
     if (co2 == 0 || co2 > 10000) { // 0 ppm is invalid; >10000 is out of K30 range
-      XBee.println("ERROR: Invalid CO2 reading: " + String(co2));
+      XBee.println(F("ERROR: Invalid CO2 reading: " + String(co2)));
       delay(RETRY_BACKOFF_MS);
-      continue
-    };  
+      continue;
+    }
 
     // Successful read with valid checksum and plausible CO2 value
     return co2;
@@ -202,7 +207,7 @@ int readK30_CO2_withRetry() {
 //   Reference: NXP UM10204 I2C-bus specification §3.1.16
 // ══════════════════════════════════════════════════════════════════════════════
 void recoverI2CBus() {
-  XBee.println("Recovering I2C bus...");
+  XBee.println(F("Recovering I2C bus..."));
 
   // Release the Wire library before bit-banging the pins directly.
   Wire.end();

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -1,6 +1,6 @@
-// Arduino sketch for reading Sensair K30 CO2 sensor over I2C and sending data via XBee.
-// Includes a retry mechanism and bus recovery to handle common I2C issues with the K30
-// when used with long wires or in electrically noisy environments.
+// Arduino sketch for reading Sensair K30 CO2 sensor over I2C and sending data via XBee
+// or Serial. Includes a retry mechanism and bus recovery to handle common I2C issues 
+// with the K30 when used with long wires or in electrically noisy environments.
 //
 // Error handling and expected behavior is designed according to Sensair data sheet:
 // https://rmtplusstoragesenseair.blob.core.windows.net/docs/Dev/publicerat/TDE4700.pdf
@@ -11,15 +11,20 @@
 // TODO
 // - Check "Error Status" at 0x1E (See section 8 of data sheet) periodically
 //   to detect sensor faults (e.g. dirty optics) and report them via XBee.
-// - Non-blocking startup timer to allow K30 warm-up without triggering watchdog timer
+// - When used with a data logger, switch to a non-blocking startup timer to 
+//   allow K30 warm-up without triggering watchdog timer
 //
 
 #include <Wire.h>
 #include <SoftwareSerial.h>
 
-// Logging
+// Logging Method
 // Set to 1 to log over XBee, 0 to log over USB Serial
 #define USE_XBEE 1
+
+// K30 configuration
+// Changed from 0x68 to 0x69 to avoid conflict with the data logger
+#define K30_I2C_ADDR 0x69     // K30 default 7-bit address: 0x68; Any Sensor address: 0x7F
 
 #if USE_XBEE
   #define LOG_STREAM XBee
@@ -31,11 +36,6 @@
 // On XBee: Use 115200 to minimize interference with actuator servo
 #define XBEE_BAUD_RATE 115200  
 #define SERIAL_BAUD_RATE 9600
-
-// K30 configuration
-// Changed from 0x68 to 0x69 to avoid conflict with the data logger
-#define K30_I2C_ADDR 0x69     // K30 default 7-bit address: 0x68; Any Sensor address: 0x7F
-#define MAX_RETRIES 3         // Retries before resetting I2C bus
 
 // I2C hardware pins (Uno/Nano): A4 = SDA, A5 = SCL
 // These two pins are also used for the software I2C bus-recovery routine.
@@ -52,6 +52,8 @@
 #define RETRY_BACKOFF_MS 50   // extra wait between retries
 #define WARMUP_MS 10000UL     // K30 power-on warm-up
 
+// Retry configuration
+#define MAX_RETRIES 3         // Retries before resetting I2C bus
 
 // Set up XBee on digital pins 2 and 3
 #if USE_XBEE

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -46,7 +46,9 @@
 // Set up XBee on digital pins 2 and 3
 SoftwareSerial XBee(2, 3); // Arduino RX, TX (XBee Dout, Din)
 
+// Forward Declarations
 int16_t readK30_CO2_withRetry();
+void recoverI2CBus();
 
 void setup() {
   

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -17,10 +17,13 @@
 #include <Wire.h>
 #include <SoftwareSerial.h>
 
-// XBee configuration
-// Use 115200 to minimize interference with actuator servo
-// Default is 9600 but that can cause more noise issues on the I2C
+// Logging stream (XBee) for debug output. 
+#define LOG_STREAM XBee // Alternative: "Serial" for USB serial debugging
+
+// Communication
+// On XBee: Use 115200 to minimize interference with actuator servo
 #define XBEE_BAUD_RATE 115200  
+#define SERIAL_BAUD_RATE 9600
 
 // K30 configuration
 // Changed from 0x68 to 0x69 to avoid conflict with the data logger
@@ -44,7 +47,9 @@
 
 
 // Set up XBee on digital pins 2 and 3
-SoftwareSerial XBee(2, 3); // Arduino RX, TX (XBee Dout, Din)
+if (LOG_STREAM == XBee) {
+  SoftwareSerial XBee(2, 3); // Arduino RX, TX (XBee Dout, Din)
+}
 
 // Forward Declarations
 int16_t readK30_CO2_withRetry();
@@ -53,7 +58,12 @@ void recoverI2CBus();
 void setup() {
   
   // Initialize XBee Software Serial port. 
-  XBee.begin(XBEE_BAUD_RATE); 
+  if (LOG_STREAM == XBee) {
+    XBee.begin(XBEE_BAUD_RATE); 
+  } 
+  if (LOG_STREAM == Serial) {
+     Serial.begin(SERIAL_BAUD_RATE);
+    }
   
   // Initialize I2C
   Wire.begin();
@@ -63,16 +73,16 @@ void setup() {
   // Warning: This will trigger the watchdog timer in the production system
   // but is necessary to prevent the K30 from locking up when the system first powers on.
   // TODO: figure out how to create a non-blocking startup timer that allows the K30 to warm up without triggering the watchdog.
-  XBee.print(F("K30 I2C CO2 sensor - warming up..."));  
+  LOG_STREAM.print(F("K30 I2C CO2 sensor - warming up..."));  
   delay(WARMUP_MS);
 
   // TODO - Check "Error Status" at 0x1E (See section 8 of data sheet) 
   // to detect sensor faults before continuing
 
-  XBee.println(F("Ready."));
+  LOG_STREAM.println(F("Ready."));
 
   // Put the I2C bus into a known state
-  XBee.print(F("Initializing I2C bus..."));
+  LOG_STREAM.print(F("Initializing I2C bus..."));
   recoverI2CBus();
   
 }
@@ -80,12 +90,12 @@ void setup() {
 void loop() {
   int16_t co2 = readK30_CO2_withRetry();
   if (co2 > 0) {
-    XBee.print(F("CO2 ppm: "));
-    XBee.println(co2);
+    LOG_STREAM.print(F("CO2 ppm: "));
+    LOG_STREAM.println(co2);
     
   } else {
-    XBee.println(F("CO2 read failed after retries"));
-    XBee.println(F("Recovering I2C bus..."));
+    LOG_STREAM.println(F("CO2 read failed after retries"));
+    LOG_STREAM.println(F("Recovering I2C bus..."));
     recoverI2CBus();
   }
   // K30 can lock up if read too frequently, so delay before next read
@@ -113,7 +123,8 @@ int16_t readK30_CO2_withRetry() {
     uint8_t err = Wire.endTransmission();
     if (err != 0) {
       // err codes: 1=data too long, 2=NACK on address, 3=NACK on data, 4=other
-      XBee.print(F("endTransmission error: ")); XBee.println(err);
+      LOG_STREAM.print(F("endTransmission error: ")); 
+      LOG_STREAM.println(err);
       delay(RETRY_BACKOFF_MS);
       continue;
     }
@@ -136,12 +147,12 @@ int16_t readK30_CO2_withRetry() {
 
     // Confirm we got 4 bytes back; if not, something went wrong at the I2C level.
     if (received != 4) { // alternative: Wire.available() != 4
-      XBee.print(F("ERROR: Expected 4 bytes, got "));
-      XBee.println(received);
+      LOG_STREAM.print(F("ERROR: Expected 4 bytes, got "));
+      LOG_STREAM.println(received);
       // Drain any leftover bytes to avoid poisoning the next transaction.
-      XBee.print(F("Flushing I2C buffer..."));
+      LOG_STREAM.print(F("Flushing I2C buffer..."));
       while (Wire.available()) Wire.read();  // flush partial data
-      XBee.println(F("done"));
+      LOG_STREAM.println(F("done"));
       delay(RETRY_BACKOFF_MS);
       continue;
     }
@@ -164,20 +175,20 @@ int16_t readK30_CO2_withRetry() {
     // This is a redundant check given the earlier check on Wire.requestFrom(), 
     // but is used here to guard against and troubleshoot I2C lockups
     if (bytesRead != 4) {
-      XBee.print(F("ERROR: Timeout Occurred. Loaded "));
-      XBee.print(bytesRead);
-      XBee.println(F(" bytes instead of 4"));
-      XBee.print(F("Flushing I2C buffer..."));
+      LOG_STREAM.print(F("ERROR: Timeout Occurred. Loaded "));
+      LOG_STREAM.print(bytesRead);
+      LOG_STREAM.println(F(" bytes instead of 4"));
+      LOG_STREAM.print(F("Flushing I2C buffer..."));
       while (Wire.available()) Wire.read();  // flush partial data
-      XBee.println(F("done"));
+      LOG_STREAM.println(F("done"));
       delay(RETRY_BACKOFF_MS);
       continue;  // retry
     }
 
     // Expect status byte 0x21 "Read Complete"
     if (buf[0] != 0x21) {
-      XBee.print(F("ERROR: Sensor status indicates read incomplete: 0x")); 
-      XBee.println(buf[0], HEX);
+      LOG_STREAM.print(F("ERROR: Sensor status indicates read incomplete: 0x")); 
+      LOG_STREAM.println(buf[0], HEX);
       delay(RETRY_BACKOFF_MS);
       continue;
     }
@@ -185,7 +196,7 @@ int16_t readK30_CO2_withRetry() {
     // Verify checksum
     uint8_t checksum = buf[0] + buf[1] + buf[2];
     if (checksum != buf[3]) {
-      XBee.println(F("ERROR: Checksum fail"));
+      LOG_STREAM.println(F("ERROR: Checksum fail"));
       delay(RETRY_BACKOFF_MS);
       continue;
     }
@@ -199,8 +210,8 @@ int16_t readK30_CO2_withRetry() {
 
     // Expect CO2 in a reasonable range for ambient air; if not, something went wrong
     if (co2 == 0 || co2 > 10000) { // 0 ppm is invalid; >10000 is out of K30 range
-      XBee.print(F("ERROR: Invalid CO2 reading: ") );
-      XBee.println(co2);
+      LOG_STREAM.print(F("ERROR: Invalid CO2 reading: ") );
+      LOG_STREAM.println(co2);
       delay(RETRY_BACKOFF_MS);
       continue;
     }
@@ -263,5 +274,5 @@ void recoverI2CBus() {
   Wire.begin();
   Wire.setClock(I2C_CLOCK_SPEED);
 
-  XBee.println(F("I2C bus initialized"));
+  LOG_STREAM.println(F("I2C bus initialized"));
 }

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -46,14 +46,18 @@
 // Set up XBee on digital pins 2 and 3
 SoftwareSerial XBee(2, 3); // Arduino RX, TX (XBee Dout, Din)
 
+int16_t readK30_CO2_withRetry();
+
 void setup() {
   
   // Initialize XBee Software Serial port. 
   XBee.begin(XBEE_BAUD_RATE); 
   
+  // Initialize I2C
   Wire.begin();
   Wire.setClock(I2C_CLOCK_SPEED); 
   
+  // Initizialize K30 sensor
   // Warning: This will trigger the watchdog timer in the production system
   // but is necessary to prevent the K30 from locking up when the system first powers on.
   // TODO: figure out how to create a non-blocking startup timer that allows the K30 to warm up without triggering the watchdog.
@@ -72,7 +76,7 @@ void setup() {
 }
 
 void loop() {
-  int co2 = readK30_CO2_withRetry();
+  int16_t co2 = readK30_CO2_withRetry();
   if (co2 > 0) {
     XBee.print(F("CO2 ppm: "));
     XBee.println(co2);
@@ -86,8 +90,8 @@ void loop() {
   delay(2500);
 }
 
-// Returns ppm or -1 on failure
-int readK30_CO2_withRetry() {
+// Returns CO2 in ppm as int16_t, or 0 on failure.
+int16_t readK30_CO2_withRetry() {
   for (int retry = 0; retry < MAX_RETRIES; retry++) {
     Wire.beginTransmission(K30_I2C_ADDR);
 
@@ -200,7 +204,7 @@ int readK30_CO2_withRetry() {
     // Successful read with valid checksum and plausible CO2 value
     return co2;
   }
-  return -1;
+  return 0; // indicate failure after retries
 }
 
 // ══════════════════════════════════════════════════════════════════════════════

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -17,8 +17,15 @@
 #include <Wire.h>
 #include <SoftwareSerial.h>
 
-// Logging stream (XBee) for debug output. 
-#define LOG_STREAM XBee // Alternative: "Serial" for USB serial debugging
+// Logging
+// Set to 1 to log over XBee, 0 to log over USB Serial
+#define USE_XBEE 1
+
+#if USE_XBEE
+  #define LOG_STREAM XBee
+#else
+  #define LOG_STREAM Serial
+#endif
 
 // Communication
 // On XBee: Use 115200 to minimize interference with actuator servo
@@ -47,9 +54,9 @@
 
 
 // Set up XBee on digital pins 2 and 3
-if (LOG_STREAM == XBee) {
+#if USE_XBEE
   SoftwareSerial XBee(2, 3); // Arduino RX, TX (XBee Dout, Din)
-}
+#endif
 
 // Forward Declarations
 int16_t readK30_CO2_withRetry();
@@ -57,13 +64,12 @@ void recoverI2CBus();
 
 void setup() {
   
-  // Initialize XBee Software Serial port. 
-  if (LOG_STREAM == XBee) {
-    XBee.begin(XBEE_BAUD_RATE); 
-  } 
-  if (LOG_STREAM == Serial) {
-     Serial.begin(SERIAL_BAUD_RATE);
-    }
+  // Initialize log stream
+#if USE_XBEE
+  XBee.begin(XBEE_BAUD_RATE);
+#else
+  Serial.begin(SERIAL_BAUD_RATE);
+#endif
   
   // Initialize I2C
   Wire.begin();

--- a/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
+++ b/Sensair/Sensair_Arduino_I2C/Arduino_to_I2C/Arduino_to_I2C.ino
@@ -231,6 +231,7 @@ void recoverI2CBus() {
   pinMode(I2C_SDA_PIN, INPUT_PULLUP);
   delayMicroseconds(5);
 
+  // Send 9 clock pulses to unstick any device holding SDA low
   for (uint8_t i = 0; i < 9; i++) {
     digitalWrite(I2C_SCL_PIN, HIGH);
     delayMicroseconds(5);


### PR DESCRIPTION
The existing testing code is used verbatim in several projects, but has significant problems with error handling, silent failures, I2C bus lockups and does not address K30's hardware limitation that holds SCL low to force an I2C bus master to wait.

The proposed code addresses these limitations.  It has been tested on an Arduino R4 that also includes a data logger, SHT humidity sensor, and XBee communication interface. 